### PR TITLE
Lecture 2023-11-21: Error Handling: Custom Error Types

### DIFF
--- a/lecture-2023-10-31-xchat/Cargo.lock
+++ b/lecture-2023-10-31-xchat/Cargo.lock
@@ -542,6 +542,7 @@ dependencies = [
  "argparse",
  "rayon",
  "shared",
+ "thiserror",
  "tokio",
 ]
 
@@ -583,6 +584,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/lecture-2023-10-31-xchat/Cargo.lock
+++ b/lecture-2023-10-31-xchat/Cargo.lock
@@ -124,8 +124,36 @@ version = "0.1.0"
 dependencies = [
  "argparse",
  "chrono",
+ "color-eyre",
  "image",
  "shared",
+]
+
+[[package]]
+name = "color-eyre"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
 ]
 
 [[package]]
@@ -208,6 +236,16 @@ dependencies = [
  "rayon-core",
  "smallvec",
  "zune-inflate",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80f656be11ddf91bd709454d15d5bd896fbaf4cc3314e69349e4d1569f5b46cd"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -312,6 +350,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "jpeg-decoder"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +372,12 @@ checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lebe"
@@ -426,6 +476,12 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "pin-project-lite"
@@ -547,6 +603,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared"
 version = "0.1.0"
 dependencies = [
@@ -607,6 +672,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tiff"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,10 +703,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "wasm-bindgen"

--- a/lecture-2023-10-31-xchat/client/Cargo.toml
+++ b/lecture-2023-10-31-xchat/client/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2021"
 [dependencies]
 argparse = "0.2.2"
 chrono = "0.4.31"
+color-eyre = "0.6.2"
 image = "0.24.7"
 shared = { path = "../shared" }

--- a/lecture-2023-10-31-xchat/client/src/lib.rs
+++ b/lecture-2023-10-31-xchat/client/src/lib.rs
@@ -13,7 +13,7 @@ use std::time;
 use color_eyre::eyre;
 #[cfg(not(debug_assertions))]
 use ::anyhow as eyre;
-use eyre::{anyhow, Result, Context};
+use eyre::{bail, Result, Context};
 
 use commands::{Command, MessageType};
 use shared::{Message, panic_to_text};
@@ -36,10 +36,10 @@ pub fn run_interactive(address: &str) -> Result<()> {
 
     let mut stream = match TcpStream::connect(address) {
         Ok(stream) => stream,
-        Err(err) => Err(format!("failed to connect: {}", err.to_string()))?,
+        Err(err) => bail!("failed to connect: {}", err.to_string()),
     };
     if let Err(err) = stream.set_nonblocking(true) {
-        Err(format!("failed to set stream attribute: {}", err.to_string()))?;
+        bail!("failed to set stream attribute: {}", err.to_string());
     }
 
     // Channel for sending of commands from input thread to processing thread.
@@ -201,10 +201,9 @@ pub fn run_interactive(address: &str) -> Result<()> {
 
 
 /// `join_thread` is just a helper function converting possible errors from thread panicking.
-fn join_thread<T: Display>(handle: JoinHandle<T>) -> Result<()> {
-    match handle.join() {
-        Ok(ok) => {},
-        Err(err) => anyhow!("thread panicked: {}", panic_to_text(err)),
+fn join_thread<T>(handle: JoinHandle<T>) -> Result<()> {
+    if let Err(err) = handle.join() {
+        bail!("thread panicked: {}", panic_to_text(err))
     };
     Ok(())
 }
@@ -216,7 +215,7 @@ fn save_image(payload: Vec<u8>) -> Result<()> {
     use std::time::SystemTime;
 
     let now: DateTime<Local> = SystemTime::now().into();
-    let timestamp = now.format("%Y-%m-%dT%H:%I");
+    let timestamp = now.format("%Y-%m-%dT%H:%M:%S");
 
     let filepath_str = format!("./images/{}.png", timestamp);
     let filepath = Path::new(filepath_str.as_str());
@@ -240,18 +239,18 @@ fn save_file(filename: &String, payload: Vec<u8>) -> Result<()> {
 fn _save_file(filepath: &Path, content: Vec<u8>) -> Result<()> {
     // create needed directories on path to the target file (if needed)
     if let Err(err) = create_dir_all(filepath.parent().unwrap()) {
-        anyhow!("failed to prepare directories: {}", err.to_string());
+        bail!("failed to prepare directories: {}", err.to_string());
     }
 
     // create a new file (possibly truncating any already existing)
     let mut f = match File::create(&filepath) {
         Ok(file) => file,
-        Err(err) => anyhow!("failed to create file: {}", err.to_string()),
+        Err(err) => bail!("failed to create file: {}", err.to_string()),
     };
 
     // write all the binary data into an empty file open for writing
     match f.write_all(&content) {
         Ok(_) => Ok(()),
-        Err(err) => anyhow!("failed to write into file: {}", err.to_string()),
+        Err(err) => bail!("failed to write into file: {}", err.to_string()),
     }
 }

--- a/lecture-2023-10-31-xchat/server/Cargo.toml
+++ b/lecture-2023-10-31-xchat/server/Cargo.toml
@@ -9,4 +9,5 @@ edition = "2021"
 argparse = "0.2.2"
 rayon = "1.8.0"
 shared = { path = "../shared" }
+thiserror = "1.0.50"
 tokio = "1.33.0"

--- a/lecture-2023-10-31-xchat/server/src/lib.rs
+++ b/lecture-2023-10-31-xchat/server/src/lib.rs
@@ -1,14 +1,32 @@
 use std::collections::HashMap;
-use std::error::Error;
 use std::io::ErrorKind;
 use std::net::{SocketAddr, TcpListener, TcpStream};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, atomic};
+use std::sync::atomic::Ordering::Relaxed;
 use std::thread::{spawn, sleep};
 use std::time;
 
 use rayon::prelude::*;
+use thiserror::Error;
 
-use shared::Message;
+use shared::{Message, panic_to_text};
+
+
+#[derive(Error, Debug)]
+pub enum ServerError {
+    #[error("failed to establish client connection: {0}")]
+    ClientConnectionError(String),
+    #[error("failed to get peer address after client connection: {0}")]
+    ClientPeerAddressError(String),
+    #[error("failed stream configuration after client connection: {0}")]
+    ClientStreamConfigError(String),
+    #[error("internal error: detected poisoned mutex")]
+    SharedMutexPoisonedError,
+    #[error("failed to forward message to {address}: {detail} ")]
+    ForwardMessageError{ address: String, detail: String },
+    #[error(transparent)]
+    IOError(#[from] std::io::Error),
+}
 
 
 type ClientMap = HashMap::<SocketAddr, TcpStream>;
@@ -16,55 +34,106 @@ type Clients = Arc<Mutex<ClientMap>>;
 
 
 /// `start_server` is entrypoint of server. It starts main processing loop in a separate thread
-/// while main thread keeps track on managing new client connections.
-pub fn start_server(address: &str) -> Result<(), Box<dyn Error>> {
+/// while main thread keep8s track on managing new client connections.
+pub fn start_server(address: &str) -> Result<(), ServerError> {
     let client_map: ClientMap = HashMap::new();
     let clients: Clients = Arc::new(Mutex::new(client_map));
 
+    let finish_flag = Arc::new(atomic::AtomicBool::new(false));
+
     let thread_clients = clients.clone();
-    let handle = spawn(|| chat(thread_clients) );
+    let thread_ok = finish_flag.clone();
+    let mut chat_handle = Some(spawn(||
+        chat(thread_clients, thread_ok)
+    ));
 
-    listen_and_accept(address, clients.clone())?;
 
-    let _ = handle.join();
+    let thread_address = address.to_string();
+    let thread_clients = clients.clone();
+    let thread_finish_flag = finish_flag.clone();
+    let mut server_handle = Some(spawn(move ||
+        listen_and_accept(thread_address, thread_clients, thread_finish_flag)
+    ));
 
-    Ok(())
+    let res: Result<(), ServerError> = Ok(());
+    loop {
+        if chat_handle.is_none() && server_handle.is_none() {
+            break
+        }
+
+        if let Some(handle) = chat_handle.as_ref() {
+            if handle.is_finished() {
+                match chat_handle.take().unwrap().join() {
+                    Ok(Ok(_)) => {},
+                    Ok(Err(err)) => eprintln!("CHAT THREAD ERROR: {}", err),
+                    Err(err) => {
+                        eprintln!("CHAT THREAD PANIC: {}", panic_to_text(err))
+                    },
+                };
+                finish_flag.store(true, Relaxed);
+            }
+        }
+
+        if let Some(handle) = server_handle.as_ref() {
+            if handle.is_finished() {
+                match server_handle.take().unwrap().join() {
+                    Ok(Ok(_)) => {},
+                    Ok(Err(err)) => eprintln!("SERVER THREAD ERROR: {}", err),
+                    Err(err) => {
+                        eprintln!("SERVER THREAD PANIC: {}", panic_to_text(err));
+                    }
+                }
+                finish_flag.store(true, Relaxed);
+            }
+        }
+    }
+
+    res
 }
 
 
 /// `listen_and_accept` take care of connection of new client connections.
-fn listen_and_accept(address: &str, clients: Clients) -> Result<(), Box<dyn Error>> {
+fn listen_and_accept(
+    address: String,
+    clients: Clients,
+    finish_flag: Arc<atomic::AtomicBool>,
+) -> Result<(), ServerError> {
     let listener = TcpListener::bind(address)?;
 
     for stream in listener.incoming() {
-        let stream = stream;
-        if stream.as_ref().is_err() {
-            continue
+        // Detection of error from the other thread.
+        // TODO: incomming is blocking, so we would detect it currently only on any new client conn.
+        if finish_flag.load(Relaxed) {
+            eprintln!("SERVER THREAD: got finish signal");
+            break
         }
-        let stream = stream.unwrap();
 
-        let address = stream.peer_addr();
-        if address.as_ref().is_err() {
-            continue
-        }
-        let address = address.unwrap();
+        let stream = match stream {
+            Ok(stream) => stream,
+            Err(err) => Err(ServerError::ClientConnectionError(err.to_string()))?,
+        };
 
-        // if let Err(_) = stream.set_nonblocking(true) {
-        //     continue
+        let address = match stream.peer_addr() {
+            Ok(addr) => addr,
+            Err(err) => Err(ServerError::ClientPeerAddressError(err.to_string()))?,
+        };
+
+        // if let Err(err) = stream.set_nonblocking(true) {
+        //     ServerError::ClientStreamConfigError(err.to_string())?;
         // }
-        if let Err(_) = stream.set_read_timeout(Some(time::Duration::from_nanos(10))) {
-            continue
+        if let Err(err) = stream.set_read_timeout(Some(time::Duration::from_nanos(10))) {
+            Err(ServerError::ClientStreamConfigError(err.to_string()))?;
         }
 
-        if let Err(_) = stream.set_write_timeout(Some(time::Duration::from_nanos(10))) {
-            continue
+        if let Err(err) = stream.set_write_timeout(Some(time::Duration::from_nanos(10))) {
+            Err(ServerError::ClientStreamConfigError(err.to_string()))?;
         }
 
-        let clients = clients.lock();
-        if clients.as_ref().is_err() {
-            continue
-        }
-        clients.unwrap().insert(address, stream);
+        let mut clients = match clients.lock() {
+            Ok(clients) => clients,
+            Err(_poisoned) => Err(ServerError::SharedMutexPoisonedError)?,
+        };
+        clients.insert(address, stream);
     }
 
     Ok(())
@@ -75,12 +144,20 @@ fn listen_and_accept(address: &str, clients: Clients) -> Result<(), Box<dyn Erro
 ///   1. try to receive a message from each of connected clients
 ///   2. broadcast each received message to each other connected client
 ///   3. removal of disconnected clients from the internal map
-fn chat(clients: Clients) {
+fn chat(
+    clients: Clients,
+    finish_flag: Arc<atomic::AtomicBool>,
+)  -> Result<(), ServerError> {
     let delay = time::Duration::from_micros(10);
     let mut message_queue: Vec<(SocketAddr, Message)> = vec![];
     let mut close_queue: Vec<SocketAddr> = vec![];
 
     loop {
+        // Detection of error from the other thread.
+        if finish_flag.load(Relaxed) {
+            return Ok(());
+        }
+
         message_queue.clear();
         close_queue.clear();
 
@@ -115,9 +192,9 @@ fn chat(clients: Clients) {
         // Broadcasting messages stored in `message_queue`.
         if !message_queue.is_empty() {
             message_queue.par_iter().for_each(|(address, message)| {
-                match send_to_everyone_else(&clients, address, message) {
-                    Ok(_) => {},
-                    Err(err) => eprintln!("sending failed: {}", err.to_string()),
+                let result = send_to_everyone_else(&clients, address, message);
+                if let Err(err) = result {
+                    eprintln!("{}", err.to_string())
                 }
             });
         }
@@ -140,13 +217,18 @@ fn send_to_everyone_else(
     clients: &Clients,
     source_address: &SocketAddr,
     message: &Message,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<(), ServerError> {
     for (address, stream) in clients.lock().unwrap().iter_mut() {
         if address == source_address {
             continue
         }
 
-        message.send(stream)?;
+        if let Err(err) = message.send(stream) {
+            Err(ServerError::ForwardMessageError{
+                address: address.to_string(),
+                detail: err.to_string(),
+            })?;
+        }
     }
 
     Ok(())

--- a/lecture-2023-10-31-xchat/shared/src/lib.rs
+++ b/lecture-2023-10-31-xchat/shared/src/lib.rs
@@ -1,3 +1,5 @@
 mod message;
+mod panic;
 
 pub use message::Message;
+pub use panic::panic_to_text;

--- a/lecture-2023-10-31-xchat/shared/src/panic.rs
+++ b/lecture-2023-10-31-xchat/shared/src/panic.rs
@@ -1,0 +1,14 @@
+use std::any::Any;
+
+
+pub fn panic_to_text(error: Box<dyn Any + Send>) -> String {
+    if let Some(str) = error.downcast_ref::<String>() {
+        return str.clone();
+    }
+
+    if let Ok(str) = error.downcast::<&str>() {
+        return str.to_string();
+    }
+
+    return "Unknown error".to_string();
+}


### PR DESCRIPTION
This PR will represent the status of homework for the lecture from 2023-11-21.

There is an extra branch _lecture-2023-11-21-error-handling-custom-error-types_ with all the code on top of the branch _lecture-2023-11-07-ecosystem_.

Perhaps there is not done all that was expected at all... Anyway, my approach was to get used to how `thiserror` and `anyhow` crates are working. To be true, I did not use just `anyhow`, I used derived `color-eyre` crate instead.

I really liked the conditional usage of `cfg(debug_assertions)` conditional compilation (presented on one of last lectures), so I used it here also. I have found it possibly useful in any of my future projects.