### PR TITLE
Lecture 2023-12-05: Web development

### DIFF
--- a/lecture-2023-10-31-xchat/Cargo.lock
+++ b/lecture-2023-10-31-xchat/Cargo.lock
@@ -67,6 +67,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f8ebf5827e4ac4fd5946560e6a99776ea73b596d80898f357007317a7141e47"
 
 [[package]]
+name = "async-trait"
+version = "0.1.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +101,59 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202651474fe73c62d9e0a56c6133f7a0ff1dc1c8cf7a5b03381af2a26553ac9d"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77cb22c689c44d4c07b0ab44ebc25d69d8ae601a2f28fb8d672d344178fa17aa"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "backtrace"
@@ -492,6 +556,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +710,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
+name = "h2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d308f63daf4181410c242d34c11f928dcb3aa105852019e043c9d1f4e4368a"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +808,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f9214f3e703236b221f1a9cd88ec8b4adfa5296de01ab96216361f4692f56"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca339002caeb0d159cc6e023dff48e199f081e42fa039895c7c6f38b37f2e9d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -883,6 +1057,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,6 +1086,12 @@ checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -1097,6 +1283,26 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1311,6 +1517,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,10 +1576,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "server"
 version = "0.1.0"
 dependencies = [
  "argparse",
+ "axum",
  "chrono",
  "futures",
  "rayon",
@@ -1742,6 +1977,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "tempfile"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1850,6 +2091,48 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"

--- a/lecture-2023-10-31-xchat/Cargo.lock
+++ b/lecture-2023-10-31-xchat/Cargo.lock
@@ -274,6 +274,7 @@ dependencies = [
  "color-eyre",
  "flume",
  "image",
+ "md5",
  "shared",
  "tokio",
 ]
@@ -1071,6 +1072,12 @@ dependencies = [
  "cfg-if",
  "digest",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"

--- a/lecture-2023-10-31-xchat/Cargo.lock
+++ b/lecture-2023-10-31-xchat/Cargo.lock
@@ -1543,9 +1543,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.190"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
@@ -1562,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.190"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1613,6 +1613,7 @@ dependencies = [
  "chrono",
  "futures",
  "rayon",
+ "serde",
  "shared",
  "sqlx",
  "thiserror",

--- a/lecture-2023-10-31-xchat/client/Cargo.toml
+++ b/lecture-2023-10-31-xchat/client/Cargo.toml
@@ -11,5 +11,6 @@ chrono = "0.4.31"
 color-eyre = "0.6.2"
 flume = "0.11.0"
 image = "0.24.7"
+md5 = "0.7.0"
 shared = { path = "../shared" }
 tokio = { version = "1.34.0", features = ["net", "full"] }

--- a/lecture-2023-10-31-xchat/client/src/lib.rs
+++ b/lecture-2023-10-31-xchat/client/src/lib.rs
@@ -256,7 +256,7 @@ pub async fn _login(stream: &mut TcpStream, login: &str, pass: &str) -> Result<S
 
     let message = Message::Login {
         login: login.to_string(),
-        pass: pass.to_uppercase(),  // imagine that conversion to uppercase is password hashing
+        pass: format!("{:x}", md5::compute(pass)),
     };
 
     match message.send(stream).await {

--- a/lecture-2023-10-31-xchat/server/Cargo.toml
+++ b/lecture-2023-10-31-xchat/server/Cargo.toml
@@ -11,6 +11,7 @@ axum = "0.7.2"
 chrono = "0.4.31"
 futures = "0.3.29"
 rayon = "1.8.0"
+serde = { version = "1.0.193", features = ["derive"] }
 shared = { path = "../shared" }
 sqlx = { version = "0.7.3", features = ["runtime-tokio", "sqlite"] }
 thiserror = "1.0.50"

--- a/lecture-2023-10-31-xchat/server/Cargo.toml
+++ b/lecture-2023-10-31-xchat/server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 argparse = "0.2.2"
+axum = "0.7.2"
 chrono = "0.4.31"
 futures = "0.3.29"
 rayon = "1.8.0"

--- a/lecture-2023-10-31-xchat/server/migrations/20231206085908_initial.sql
+++ b/lecture-2023-10-31-xchat/server/migrations/20231206085908_initial.sql
@@ -1,13 +1,20 @@
--- Add migration script here
+CREATE TABLE IF NOT EXISTS users (
+     id         INTEGER PRIMARY KEY NOT NULL,
+     login      TEXT NOT NULL,
+     password   TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS chat_messages (
     id          INTEGER PRIMARY KEY NOT NULL,
-    login       TEXT NOT NULL,
+    user_id     INTEGER NOT NULL,
     timestamp   TEXT NOT NULL,
-    text        TEXT NOT NULL
+    text        TEXT NOT NULL,
+    FOREIGN KEY(user_id) REFERENCES users(id)
 );
 
 CREATE TABLE IF NOT EXISTS client_logins (
     id          INTEGER PRIMARY KEY NOT NULL,
-    login       TEXT NOT NULL,
-    timestamp   TEXT NOT NULL
+    user_id     INTEGER NOT NULL,
+    timestamp   TEXT NOT NULL,
+    FOREIGN KEY(user_id) REFERENCES users(id)
 );

--- a/lecture-2023-10-31-xchat/server/migrations/20231210171047_initial_users.sql
+++ b/lecture-2023-10-31-xchat/server/migrations/20231210171047_initial_users.sql
@@ -1,0 +1,12 @@
+DELETE FROM users
+WHERE login IN ('TheOne', 'JustTwo', 'Threesome');
+
+INSERT INTO users
+(login, password)
+VALUES
+-- password = MD5 of string '1'
+('TheOne', 'c4ca4238a0b923820dcc509a6f75849b'),
+-- password = MD5 of string '2'
+('JustTwo', 'c81e728d9d4c2f636f067f89cc14862c'),
+-- password = MD5 of string '3'
+('Threesome', 'eccbc87e4b5ce2fe28308fd9f2a7baf3');

--- a/lecture-2023-10-31-xchat/server/src/db_queries.rs
+++ b/lecture-2023-10-31-xchat/server/src/db_queries.rs
@@ -1,16 +1,51 @@
 use std::result::Result;
 
-use sqlx::query;
+use sqlx::{query, query_as};
 use sqlx::sqlite::{SqlitePool};
 
 use crate::ServerError;
+
+
+#[derive(Clone, Debug)]
+pub struct DbUser {
+    pub id: i64,
+    pub login: String,
+    #[allow(dead_code)]
+    password: String,
+}
+
+
+/// `fetch_user_by_login_and_password` receives a user from the `users` table.
+pub async fn fetch_user_by_login_and_password(
+        pool: &SqlitePool,
+        login: &str,
+        password: &str,
+) -> Result<Option<DbUser>, ServerError> {
+    match query_as!(
+        DbUser,
+        r#"
+SELECT *
+FROM users
+WHERE
+    login = ?1
+    AND
+    LOWER(password) = LOWER(?2)
+;"#,
+        login,
+        password,
+    ).fetch_one(pool).await {
+        Ok(user) => Ok(Some(user)),
+        Err(sqlx::Error::RowNotFound) => Ok(None),
+        Err(err) => Err(ServerError::DBError(err.to_string())),
+    }
+}
 
 
 /// `insert_login` inserts a single complete row into the `client_logins` table.
 /// Internal ID comes from a internal DB sequence.
 pub async fn insert_login(
         pool: &SqlitePool,
-        login: &str,
+        user_id: i64,
         timestamp: &str,
 ) -> Result<(), ServerError> {
     let mut conn = match pool.acquire().await {
@@ -21,11 +56,11 @@ pub async fn insert_login(
     match query!(
         r#"
 INSERT INTO client_logins
-(login, timestamp)
+(user_id, timestamp)
 VALUES
-(?1, ?2);
-        "#,
-        login,
+(?1, ?2)
+;"#,
+        user_id,
         timestamp,
     ).execute(&mut *conn).await {
         Ok(_) => Ok(()),
@@ -38,7 +73,7 @@ VALUES
 /// Internal ID comes from a internal DB sequence.
 pub async fn insert_chat_message(
         pool: &SqlitePool,
-        login: &str,
+        user_id: i64,
         timestamp: &str,
         text: &str,
 ) -> Result<(), ServerError> {
@@ -50,11 +85,11 @@ pub async fn insert_chat_message(
     match query!(
         r#"
 INSERT INTO chat_messages
-(login, timestamp, text)
+(user_id, timestamp, text)
 VALUES
-(?1, ?2, ?3);
-        "#,
-        login,
+(?1, ?2, ?3)
+;"#,
+        user_id,
         timestamp,
         text,
     ).execute(&mut *conn).await {

--- a/lecture-2023-10-31-xchat/server/src/db_queries.rs
+++ b/lecture-2023-10-31-xchat/server/src/db_queries.rs
@@ -14,6 +14,12 @@ pub struct DbUser {
     password: String,
 }
 
+pub struct ChatMessage {
+    pub login: String,
+    pub timestamp: String,
+    pub text: String,
+}
+
 
 /// `fetch_user_by_login_and_password` receives a user from the `users` table.
 pub async fn fetch_user_by_login_and_password(
@@ -36,6 +42,29 @@ WHERE
     ).fetch_one(pool).await {
         Ok(user) => Ok(Some(user)),
         Err(sqlx::Error::RowNotFound) => Ok(None),
+        Err(err) => Err(ServerError::DBError(err.to_string())),
+    }
+}
+
+
+pub async fn fetch_chat_messages(
+    pool: &SqlitePool,
+) -> Result<Vec<ChatMessage>, ServerError> {
+    match query_as!(
+        ChatMessage,
+        r#"
+SELECT
+    u.login AS login,
+    cm.timestamp AS timestamp,
+    cm.text AS text
+FROM
+    chat_messages AS cm
+    JOIN users AS u ON u.id = cm.user_id
+ORDER BY timestamp DESC
+;"#,
+    ).fetch_all(pool).await {
+        Ok(chat_messages) => Ok(chat_messages),
+        Err(sqlx::Error::RowNotFound) => Ok(vec![]),
         Err(err) => Err(ServerError::DBError(err.to_string())),
     }
 }

--- a/lecture-2023-10-31-xchat/server/src/error.rs
+++ b/lecture-2023-10-31-xchat/server/src/error.rs
@@ -1,0 +1,26 @@
+use thiserror::Error;
+
+
+#[derive(Error, Debug)]
+pub enum ServerError {
+    #[error("failed port binding: {0}")]
+    PortBindError(String),
+    #[error("failed to establish client connection: {0}")]
+    ClientConnectionError(String),
+    #[error("failed to get peer address after client connection: {0}")]
+    ClientPeerAddressError(String),
+    #[error("failed stream configuration after client connection: {0}")]
+    ClientStreamConfigError(String),
+    #[error("internal error: detected poisoned mutex")]
+    SharedMutexPoisonedError,
+    #[error("failed to forward message to {address}: {detail} ")]
+    ForwardMessageError{ address: String, detail: String },
+    #[error("DB error: {0}")]
+    DBError(String),
+    #[error("web server error: {0}")]
+    WebServerError(String),
+    #[error(transparent)]
+    IOError(#[from] std::io::Error),
+    #[error("join error: {0}")]
+    JoinError(String),
+}

--- a/lecture-2023-10-31-xchat/server/src/main.rs
+++ b/lecture-2023-10-31-xchat/server/src/main.rs
@@ -1,17 +1,20 @@
+use std::process::exit;
+
 use server::start_server;
 
 
 #[tokio::main]
 async fn main() {
-    let mut hostname = "localhost".to_string();
-    let mut port = 11111_u16;
+    let mut comm_hostname = "localhost".to_string();
+    let mut comm_port = 11111_u16;
     let mut db_url = "sqlite:data.db".to_string();
+    let mut web_port = 8080_u16;
 
-    parse_arguments(&mut hostname, &mut port, &mut db_url);
+    parse_arguments(&mut comm_hostname, &mut comm_port, &mut db_url, &mut web_port);
 
-    let address = format!("{}:{}", hostname, port);
+    let address = format!("{}:{}", comm_hostname, comm_port);
 
-    if let Err(err) = start_server(&address, &db_url).await {
+    if let Err(err) = start_server(&address, &db_url, web_port).await {
         eprintln!("{}", err);
     }
 }
@@ -20,25 +23,41 @@ async fn main() {
 /// `parse_arguments` uses [argparse](https://crates.io/crates/argparse) crate to parse command-line
 /// options.
 fn parse_arguments(
-        hostname: &mut String,
-        port: &mut u16,
-        db_url: &mut String,
+    comm_hostname: &mut String,
+    comm_port: &mut u16,
+    db_url: &mut String,
+    web_port: &mut u16,
 ) {
     use argparse::{ArgumentParser, Store};
-    use std::process::exit;
 
-    let mut _port = port.to_string();
+    let mut _comm_port = comm_port.to_string();
+    let mut _web_port = web_port.to_string();
 
     // Extra limited scope where argparse operates.
     {
         let mut ap = ArgumentParser::new();
         ap.set_description("Client for chat communication service.");
 
-        ap.refer(hostname)
-            .add_option(&["-h", "--host"], Store, "Hostname (e.g. `localhost`).");
+        ap.refer(comm_hostname)
+            .add_option(
+                &["-h", "--host"],
+                Store,
+                "Communication server hostname (e.g. `localhost`).",
+            );
 
-        ap.refer(&mut _port)
-            .add_option(&["-p", "--port"], Store, "Port number (e.g. `11111`).");
+        ap.refer(&mut _comm_port)
+            .add_option(
+                &["-p", "--port"],
+                Store,
+                "Communication server port number (e.g. `11111`).",
+            );
+
+        ap.refer(&mut _web_port)
+            .add_option(
+                &["--web-port"],
+                Store,
+                "Web server port number (e.g. 8080).",
+            );
 
         ap.refer(db_url)
             .add_option(&["--db-url"], Store, "DB URL (e.g. `sqlite:data.db`).");
@@ -48,11 +67,16 @@ fn parse_arguments(
         }
     }
 
-    // Ensure that read parse number is valid unsigned 16b integer.
-    match _port.parse::<u16>() {
-        Ok(port_number) => *port = port_number,
+    _ensure_port_number(comm_port, &_comm_port, "comm_port");
+    _ensure_port_number(web_port, &_web_port, "web_port");
+}
+
+
+fn _ensure_port_number(target: &mut u16, source: &str, arg_name: &str) {
+    match source.parse::<u16>() {
+        Ok(port_number) => *target = port_number,
         Err(_) => {
-            eprintln!("failed to parse port number");
+            eprintln!("failed to parse port number {}", arg_name);
             exit(1);
         }
     }

--- a/lecture-2023-10-31-xchat/server/src/web.rs
+++ b/lecture-2023-10-31-xchat/server/src/web.rs
@@ -1,16 +1,77 @@
-use axum::{Router, routing::get};
+use std::sync::Arc;
+
+use axum::{Router, routing::get, response::Html, Extension};
+use sqlx::SqlitePool;
 
 use crate::error::ServerError;
+use crate::db_queries::{fetch_chat_messages};
+use shared::concat;
 
 
-async fn hello_world() -> &'static str {
-    "Hello, World!"
+struct AppState {
+    db_pool: SqlitePool,
 }
 
 
-pub async fn start_web_server(port_number: u16) -> Result<(), ServerError> {
-    let router = Router::new().route("/", get(hello_world));
+async fn user_list(
+    state: Extension<Arc<AppState>>,
+) -> Html<String> {
+    let db_result = fetch_chat_messages(&state.db_pool).await;
+    if let Err(_) = db_result {
+        return Html("Failed to fetch user list!".to_string())
+    }
+
+    let mut page: Vec<String> = vec![
+        "<table>".to_string(),
+        " <tr>".to_string(),
+        "  <th>".to_string(),
+        "   timestamp".to_string(),
+        "  </th>".to_string(),
+        "  <th>".to_string(),
+        "   user".to_string(),
+        "  </th>".to_string(),
+        "  <th>".to_string(),
+        "   message".to_string(),
+        "  </th>".to_string(),
+        " </tr>".to_string(),
+    ];
+
+    for chat_message in db_result.unwrap() {
+        let mut line: Vec<String> = vec![
+            " <tr>".to_string(),
+            "  <td>".to_string(),
+            format!("   {}", chat_message.timestamp),
+            "  </td>".to_string(),
+            "  <td>".to_string(),
+            format!("   {}", chat_message.login),
+            "  </td>".to_string(),
+            "  <td>".to_string(),
+            format!("   {}", chat_message.text),
+            "  </td>".to_string(),
+            " </tr>".to_string(),
+        ];
+
+        page.append(&mut line);
+    }
+
+    page.push("</table>".to_string());
+
+    Html(concat(&page))
+}
+
+
+pub async fn start_web_server(
+    port_number: u16,
+    pool: SqlitePool,
+) -> Result<(), ServerError> {
+    let state = Arc::new(AppState { db_pool: pool });
+
+    let router = Router::new()
+        .route("/", get(user_list))
+        .layer(Extension(state));
+
     let address = format!("localhost:{}", port_number);
+
     let listener = match tokio::net::TcpListener::bind(address).await {
         Ok(listener) => listener,
         Err(err) => Err(ServerError::WebServerError(err.to_string()))?,

--- a/lecture-2023-10-31-xchat/server/src/web.rs
+++ b/lecture-2023-10-31-xchat/server/src/web.rs
@@ -1,5 +1,3 @@
-use std::net::SocketAddr;
-
 use axum::{Router, routing::get};
 
 use crate::error::ServerError;

--- a/lecture-2023-10-31-xchat/server/src/web.rs
+++ b/lecture-2023-10-31-xchat/server/src/web.rs
@@ -1,0 +1,25 @@
+use std::net::SocketAddr;
+
+use axum::{Router, routing::get};
+
+use crate::error::ServerError;
+
+
+async fn hello_world() -> &'static str {
+    "Hello, World!"
+}
+
+
+pub async fn start_web_server(port_number: u16) -> Result<(), ServerError> {
+    let router = Router::new().route("/", get(hello_world));
+    let address = format!("localhost:{}", port_number);
+    let listener = match tokio::net::TcpListener::bind(address).await {
+        Ok(listener) => listener,
+        Err(err) => Err(ServerError::WebServerError(err.to_string()))?,
+    };
+
+    match axum::serve(listener, router.into_make_service()).await {
+        Ok(_) => Ok(()),
+        Err(err) => Err(ServerError::WebServerError(err.to_string())),
+    }
+}

--- a/lecture-2023-10-31-xchat/server/src/web.rs
+++ b/lecture-2023-10-31-xchat/server/src/web.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use sqlx::SqlitePool;
 
 use crate::error::ServerError;
-use crate::db_queries::{fetch_chat_messages, fetch_users};
+use crate::db_queries::{fetch_chat_messages, fetch_users, delete_user_by_id};
 use shared::concat;
 
 
@@ -16,16 +16,45 @@ struct AppState {
 }
 
 
+/// `start_web_server` is entrypoint for web server part of server crate.
+pub async fn start_web_server(
+    port_number: u16,
+    pool: SqlitePool,
+) -> Result<(), ServerError> {
+    let address = format!("localhost:{}", port_number);
+
+    let state = Arc::new(AppState {
+        db_pool: pool,
+        host: address.clone(),
+    });
+
+    let router = Router::new()
+        .route("/", get(user_list))
+        .route("/delete_user", get(delete_user))
+        .layer(Extension(state));
+
+    let listener = match tokio::net::TcpListener::bind(address).await {
+        Ok(listener) => listener,
+        Err(err) => Err(ServerError::WebServerError(err.to_string()))?,
+    };
+
+    match axum::serve(listener, router.into_make_service()).await {
+        Ok(_) => Ok(()),
+        Err(err) => Err(ServerError::WebServerError(err.to_string())),
+    }
+}
+
+
 #[derive(Deserialize)]
-struct LoginFilter {
+struct LoginFilterParam {
     login: Option<String>,
 }
 
 
-/// `user_list`
+/// `user_list` is main endpoint (aka landing site) for the web server.
 async fn user_list(
     state: Extension<Arc<AppState>>,
-    login_filter: Query<LoginFilter>,
+    login_filter: Query<LoginFilterParam>,
 ) -> Html<String> {
     let db_result = fetch_chat_messages(
         &state.db_pool,
@@ -42,8 +71,38 @@ async fn user_list(
     }
     let users = db_result.unwrap();
 
+    // Preparing a links for filtering by login and user deletion.
+    let mut filter_links: Vec<String> = vec![
+        format!("<p>Login filter: <a href='http://{}/'>all</a>", state.host),
+    ];
+    let mut delete_links: Vec<String> = vec![
+        "<p>Delete user: ".to_uppercase(),
+    ];
+    for user in users {
+        filter_links.push(format!(
+            ", <a href='http://{}/?login={}'>{}</a>",
+            state.host,
+            user.login,  // TODO: URL-safe encoding
+            user.login,
+        ));
+
+        delete_links.push(format!(
+            ", <a href='http://{}/delete_user?id={}&login={}'>{}</a>",
+            state.host,
+            user.id,    // TODO: perhaps base64 encoding to obfuscate it a bit...
+            user.login, // TODO: URL-safe encoding
+            user.login,
+        ));
+    }
+    let mut filter_links_html = concat(&filter_links);
+    filter_links_html.push_str("</p>");
+    let mut delete_links_html = concat(&delete_links);
+    delete_links_html.push_str("</p>");
+
+    // Construction of the top-level page layout.
     let mut page: Vec<String> = vec![
-        String::new(),
+        filter_links_html,
+        delete_links_html,
         "<table>".to_string(),
         " <tr>".to_string(),
         "  <th>".to_string(),
@@ -58,6 +117,7 @@ async fn user_list(
         " </tr>".to_string(),
     ];
 
+    // Construction of table row for each chat message.
     for chat_message in chat_messages {
         let mut line: Vec<String> = vec![
             " <tr>".to_string(),
@@ -78,46 +138,58 @@ async fn user_list(
 
     page.push("</table>".to_string());
 
-    let mut login_links: Vec<String> = vec![
-        format!("Login filter: <a href='http://{}/'>all</a>", state.host),
-    ];
-    for user in users {
-        login_links.push(format!(
-            ", <a href='http://{}/?login={}'>{}</a>",
-            state.host,
-            user.login,  // TODO: URL-safe encoding
-            user.login,
-        ));
-    }
-    page[0].push_str(concat(&login_links).as_str());
-
     Html(concat(&page))
 }
 
 
-/// `start_web_server`
-pub async fn start_web_server(
-    port_number: u16,
-    pool: SqlitePool,
-) -> Result<(), ServerError> {
-    let address = format!("localhost:{}", port_number);
+#[derive(Deserialize)]
+struct UserDeleteParam {
+    id: Option<i64>,
+    login: Option<String>,
+}
 
-    let state = Arc::new(AppState {
-        db_pool: pool,
-        host: address.clone(),
-    });
 
-    let router = Router::new()
-        .route("/", get(user_list))
-        .layer(Extension(state));
+/// `delete_user` is a web endpoint that is responsible for deletion of a single user by ID.
+async fn delete_user(
+    state: Extension<Arc<AppState>>,
+    user_delete_id: Query<UserDeleteParam>,
+) -> Html<String> {
+    let go_back = format!(
+        "<a href='http://{}'>Return back to user list.</a>",
+        state.host,
+    );
 
-    let listener = match tokio::net::TcpListener::bind(address).await {
-        Ok(listener) => listener,
-        Err(err) => Err(ServerError::WebServerError(err.to_string()))?,
+    if user_delete_id.id.is_none() && user_delete_id.login.is_none() {
+        return Html(format!("Missing id and login parameters. {}", go_back));
+    } else if user_delete_id.id.is_none() {
+        return Html(format!("Missing id parameter. {}", go_back));
+    } else if user_delete_id.login.is_none() {
+        return Html(format!("Missing login parameter. {}", go_back));
     };
 
-    match axum::serve(listener, router.into_make_service()).await {
-        Ok(_) => Ok(()),
-        Err(err) => Err(ServerError::WebServerError(err.to_string())),
+    let param_user_id = user_delete_id.id.unwrap();
+    let param_user_login = user_delete_id.login.clone().unwrap();
+
+    let db_result = fetch_users(&state.db_pool).await;
+    if let Err(_) = db_result {
+        return Html("Failed to fetch user list.".to_string())
     }
+    let users = db_result.unwrap();
+
+    let found = users.iter().any(|user| user.id == param_user_id && user.login == param_user_login);
+    if !found {
+        return Html(format!("User not found. {}", go_back));
+    };
+
+    let db_result = delete_user_by_id(&state.db_pool, param_user_id).await;
+    if let Err(_) = db_result {
+        return Html(format!("Failed to delete user. {}", go_back));
+    };
+
+    Html(format!(
+        "Successfully deleted user with id {} and login {}. {}",
+        param_user_id,
+        param_user_login,
+        go_back,
+    ))
 }

--- a/lecture-2023-10-31-xchat/server/src/web.rs
+++ b/lecture-2023-10-31-xchat/server/src/web.rs
@@ -1,27 +1,49 @@
 use std::sync::Arc;
 
 use axum::{Router, routing::get, response::Html, Extension};
+use axum::{extract::Query};
+use serde::Deserialize;
 use sqlx::SqlitePool;
 
 use crate::error::ServerError;
-use crate::db_queries::{fetch_chat_messages};
+use crate::db_queries::{fetch_chat_messages, fetch_users};
 use shared::concat;
 
 
 struct AppState {
     db_pool: SqlitePool,
+    host: String,
 }
 
 
+#[derive(Deserialize)]
+struct LoginFilter {
+    login: Option<String>,
+}
+
+
+/// `user_list`
 async fn user_list(
     state: Extension<Arc<AppState>>,
+    login_filter: Query<LoginFilter>,
 ) -> Html<String> {
-    let db_result = fetch_chat_messages(&state.db_pool).await;
+    let db_result = fetch_chat_messages(
+        &state.db_pool,
+        &login_filter.login,
+    ).await;
     if let Err(_) = db_result {
         return Html("Failed to fetch user list!".to_string())
     }
+    let chat_messages = db_result.unwrap();
+
+    let db_result = fetch_users(&state.db_pool).await;
+    if let Err(_) = db_result {
+        return Html("Failed to fetch user list!".to_string())
+    }
+    let users = db_result.unwrap();
 
     let mut page: Vec<String> = vec![
+        String::new(),
         "<table>".to_string(),
         " <tr>".to_string(),
         "  <th>".to_string(),
@@ -36,7 +58,7 @@ async fn user_list(
         " </tr>".to_string(),
     ];
 
-    for chat_message in db_result.unwrap() {
+    for chat_message in chat_messages {
         let mut line: Vec<String> = vec![
             " <tr>".to_string(),
             "  <td>".to_string(),
@@ -56,21 +78,38 @@ async fn user_list(
 
     page.push("</table>".to_string());
 
+    let mut login_links: Vec<String> = vec![
+        format!("Login filter: <a href='http://{}/'>all</a>", state.host),
+    ];
+    for user in users {
+        login_links.push(format!(
+            ", <a href='http://{}/?login={}'>{}</a>",
+            state.host,
+            user.login,  // TODO: URL-safe encoding
+            user.login,
+        ));
+    }
+    page[0].push_str(concat(&login_links).as_str());
+
     Html(concat(&page))
 }
 
 
+/// `start_web_server`
 pub async fn start_web_server(
     port_number: u16,
     pool: SqlitePool,
 ) -> Result<(), ServerError> {
-    let state = Arc::new(AppState { db_pool: pool });
+    let address = format!("localhost:{}", port_number);
+
+    let state = Arc::new(AppState {
+        db_pool: pool,
+        host: address.clone(),
+    });
 
     let router = Router::new()
         .route("/", get(user_list))
         .layer(Extension(state));
-
-    let address = format!("localhost:{}", port_number);
 
     let listener = match tokio::net::TcpListener::bind(address).await {
         Ok(listener) => listener,

--- a/lecture-2023-10-31-xchat/shared/src/lib.rs
+++ b/lecture-2023-10-31-xchat/shared/src/lib.rs
@@ -5,3 +5,22 @@ mod timestamp;
 pub use message::Message;
 pub use panic::panic_to_text;
 pub use timestamp::timestamp_to_string;
+
+
+pub fn concat(strings: &Vec<String>) -> String {
+    use std::borrow::{Borrow};
+
+    if strings.is_empty() {
+        return String::new();
+    }
+
+    // `len` calculation may overflow but push_str will check boundaries
+    let len = strings.iter().map(|s| <String as Borrow<String>>::borrow(s).len()).sum();
+    let mut result = String::with_capacity(len);
+
+    for s in strings {
+        result.push_str(s.borrow())
+    }
+
+    result
+}

--- a/lecture-2023-10-31-xchat/shared/src/timestamp.rs
+++ b/lecture-2023-10-31-xchat/shared/src/timestamp.rs
@@ -6,8 +6,6 @@ use chrono::DateTime;
 
 /// `timestamp_to_string` transforms system time (e.g. from `SystemTime::now()`) into string
 /// of form ISO 8601 (`YYYY-MM-DDThh:mm:ss`).
-///
-///
 pub fn timestamp_to_string(timestamp: SystemTime) -> String {
     let timestamp: DateTime<Local> = timestamp.into();
     let timestamp = timestamp.format("%Y-%m-%dT%H:%M:%S");


### PR DESCRIPTION
This PR will represent the status of homework for the lecture from 2023-12-05.

There is an extra branch `lecture-2023-12-05-web-devel` with all the code on top of the branch `lecture-2023-11-30-test-and-doc`.

Honorable mentions:
- Still using `sqlx` for SQLite DB. Using `query` and  `query_as` macros. It is kind of low-level, but I like it. I have even used a transaction for the deletion of the user (it was tricky because of `&mut *tx` needed to be used as the query executor, while the requirement of using `*` was not led by the error message at all...).
- For the web server part, `axum` was used (because it came from the `tokio` project). There I was struggling a lot with DB connection via shared reference. Solved by the easiest way - cloning the DB connection pool object to have there a separate instance for the web server. it worked during testing, but it might cause troubles in any production environment...
- The interface of the web server is as simple as possible. Quick & dirty generator for HTML pages + two endpoints using just GET method + query parameters + links between end-points. It is just a study project. Nothing to be proud of...
- There is finally introduced a simple but reasonable authentication (using just MD5 hash) + introduced `users` table.

Places for a better solution:
- Introducing a message to decline login in case of wrong password etc. The current solution is still relying on not connecting within a 5-second timeout.

Not so honorable mention:
 - As a side project I wanted to refactor the server crate to have there more-or-less true async server. However, I failed with that one. If one would like to see it, there is a separate branch `full-async-server`. The problem there is a bit hidden from me... If I tested with a server and 3 clients connected at the same time, The last message was always sent just to one client, and the other one got it as soon as any next message was sent... I was not able to debug this lazy behavior...