### PR TITLE
Lecture 2023-12-12: Metrics

### DIFF
--- a/lecture-2023-10-31-xchat/Cargo.lock
+++ b/lecture-2023-10-31-xchat/Cargo.lock
@@ -1379,6 +1379,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,6 +1633,8 @@ dependencies = [
  "axum",
  "chrono",
  "futures",
+ "lazy_static",
+ "prometheus",
  "rayon",
  "serde",
  "shared",

--- a/lecture-2023-10-31-xchat/docker-compose.yaml
+++ b/lecture-2023-10-31-xchat/docker-compose.yaml
@@ -1,0 +1,19 @@
+version: "3.9"
+services:
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yaml:/etc/prometheus/prometheus.yaml
+    ports:
+      - "9090:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  grafana:
+    image: grafana/grafana
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus

--- a/lecture-2023-10-31-xchat/prometheus.yaml
+++ b/lecture-2023-10-31-xchat/prometheus.yaml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: prometheus
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    static_configs:
+      - targets: ["host.docker.internal:9090"]

--- a/lecture-2023-10-31-xchat/server/Cargo.toml
+++ b/lecture-2023-10-31-xchat/server/Cargo.toml
@@ -10,6 +10,8 @@ argparse = "0.2.2"
 axum = "0.7.2"
 chrono = "0.4.31"
 futures = "0.3.29"
+lazy_static = "1.4.0"
+prometheus = "0.13.3"
 rayon = "1.8.0"
 serde = { version = "1.0.193", features = ["derive"] }
 shared = { path = "../shared" }

--- a/lecture-2023-10-31-xchat/server/src/error.rs
+++ b/lecture-2023-10-31-xchat/server/src/error.rs
@@ -21,6 +21,8 @@ pub enum ServerError {
     WebServerError(String),
     #[error(transparent)]
     IOError(#[from] std::io::Error),
+    #[error("Prometheus registration error: {0}")]
+    PrometheusRegistrationError(String),
     #[error("join error: {0}")]
     JoinError(String),
 }

--- a/lecture-2023-10-31-xchat/server/src/web_prometheus.rs
+++ b/lecture-2023-10-31-xchat/server/src/web_prometheus.rs
@@ -1,0 +1,74 @@
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use lazy_static::lazy_static;
+use prometheus::{Encoder, TextEncoder, IntCounter, IntGauge};
+use crate::error::ServerError;
+
+
+lazy_static! {
+    pub static ref SCRAPE_COUNTER: IntCounter = IntCounter::new(
+        "http_metrics_counter_scrape",
+        "How many times was scrapped "
+    ).unwrap();
+
+    pub static ref MESSAGE_COUNTER: IntCounter = IntCounter::new(
+        "http_metrics_counter_message",
+        "How many messages was sent through the running server.",
+    ).unwrap();
+
+    pub static ref SUCCESSFUL_CONNECTION_COUNTER: IntCounter = IntCounter::new(
+        "http_metrics_counter_successful_connection",
+        "How many successful connections from clients was established."
+    ).unwrap();
+
+    pub static ref NOT_AUTHORIZED_CONNECTION_COUNTER: IntCounter = IntCounter::new(
+        "http_metrics_counter_not_authorized_connection",
+        "How many authorizations from clients failed."
+    ).unwrap();
+
+    pub static ref CURRENT_CLIENT_COUNT_GAUGE: IntGauge = IntGauge::new(
+        "http_metrics_gauge_current_client_count",
+        "How many clients are currently connected."
+    ).unwrap();
+}
+
+
+pub fn register_prometheus() -> Result<(), ServerError> {
+    let counters = vec![
+        Box::new(SCRAPE_COUNTER.clone()),
+        Box::new(MESSAGE_COUNTER.clone()),
+        Box::new(SUCCESSFUL_CONNECTION_COUNTER.clone()),
+        Box::new(NOT_AUTHORIZED_CONNECTION_COUNTER.clone()),
+    ];
+
+    for counter in counters {
+        if let Err(err) = prometheus::default_registry().register(counter) {
+            Err(ServerError::PrometheusRegistrationError(err.to_string()))?;
+        }
+    };
+
+    let gauges = vec![
+        Box::new(CURRENT_CLIENT_COUNT_GAUGE.clone()),
+    ];
+
+    for gauge in gauges {
+        if let Err(err) = prometheus::default_registry().register(gauge) {
+            Err(ServerError::PrometheusRegistrationError(err.to_string()))?;
+        }
+    };
+
+    return Ok(())
+}
+
+
+pub async fn prometheus_metrics_handler() -> impl IntoResponse {
+    SCRAPE_COUNTER.inc();
+
+    let encoder = TextEncoder::new();
+    let mut buffer = vec![];
+
+    let metrics = prometheus::gather();
+    encoder.encode(&metrics, &mut buffer).unwrap();
+
+    (StatusCode::OK, buffer)
+}


### PR DESCRIPTION
This PR will represent the status of homework for the lecture from 2023-12-12.

There is an extra branch lecture-2023-12-12-metrics with all the code on top of the branch lecture-2023-12-05-web-devel.

There is:
 - added endpoint `/metrics` on existing HTTP server;
 - introduced a few metrics of types integer counter and integer gauge;
 - added very basic `docker-compose.yaml` file and `prometheus.yaml` files for easy-to-use testing.
     - However, testing from Linux might not work. It was not due to UFW nor missing `extra_hosts` nor not using 0.0.0.0 host for the web server.
     - One can still use `curl localhost:8080/metrics` to check it with the original Prometheus text format.